### PR TITLE
Return reference to result of -= operator for vector2

### DIFF
--- a/ProjectJormag/MathHelper.h
+++ b/ProjectJormag/MathHelper.h
@@ -43,6 +43,7 @@ namespace Jormag {
 		Vector2& operator -=(const Vector2& rhs) {
 			x -= rhs.x;
 			y -= rhs.y;
+			return *this;
 		}
 
 		Vector2 operator -() const {


### PR DESCRIPTION
Hi,

This PR would fix a warning about not returning anything with a non void return type method.