### PR TITLE
Return false if the check fails

### DIFF
--- a/ProjectJormag/InputManager.cpp
+++ b/ProjectJormag/InputManager.cpp
@@ -55,6 +55,7 @@ namespace Jormag {
 			if (mKeyboardState[i] != 0)
 				return true;
 		}
+		return false;
 	}
 
 	bool InputManager::AnyKeyPressed() {
@@ -62,6 +63,7 @@ namespace Jormag {
 			if (mLastKeyboardState[i] == 0 && mKeyboardState[i] != 0)
 				return true;
 		}
+		return false;
 	}
 
 	bool InputManager::AnyKeyReleased() {
@@ -69,6 +71,7 @@ namespace Jormag {
 			if (mLastKeyboardState[i] != 0 && mKeyboardState[i] == 0)
 				return true;
 		}
+		return false;
 	}
 
 	bool InputManager::MouseButtonDown(MouseButton button) {

--- a/ProjectJormag/MarioManager.cpp
+++ b/ProjectJormag/MarioManager.cpp
@@ -116,6 +116,7 @@ bool MarioManager::CheckLoss(Player* player) {
 			}
 		}
 	}
+	return false;
 }
 
 void MarioManager::CheckPowBlock(Player* player) {


### PR DESCRIPTION
Hi,

This PR would fix warnings about some methods not returning false if their checks fail.

This change includes these checks:

InputManager::AnyKeyHeld
InputManager::AnyKeyPressed
InputManager::AnyKeyReleased
MarioManager::CheckLoss