### PR TITLE
Add null initialization to pointer variables

### DIFF
--- a/ProjectJormag/EngineManager.h
+++ b/ProjectJormag/EngineManager.h
@@ -36,7 +36,7 @@ namespace Jormag {
 		Camera* mCamera;
 
 		// Runtime
-		StateManager* mCurrentGameState;
+		StateManager* mCurrentGameState = nullptr;
 	private:
 		EngineManager();
 		~EngineManager();

--- a/ProjectJormag/GameManager.h
+++ b/ProjectJormag/GameManager.h
@@ -14,10 +14,10 @@ private:
 	// Singleton Instance
 	static GameManager* sInstance;
 
-	EngineManager* mEngine;
-	MenuManager* mMenu;
-	LevelManager* mGame;
-	MarioManager* mMario;
+	EngineManager* mEngine  = nullptr;
+	MenuManager* mMenu = nullptr;
+	LevelManager* mGame = nullptr;
+	MarioManager* mMario = nullptr;
 
 	std::string mSaveDate;
 	int mTotalDeaths;

--- a/ProjectJormag/Level.h
+++ b/ProjectJormag/Level.h
@@ -57,7 +57,7 @@ private:
 	Vector2 mStartPos;
 	Vector2 mEndPos;
 
-	Texture* mBackdrops[3];
+	Texture* mBackdrops[3] = {0};
 	int*** mLevelTileData;
 	Shadow** mShadows;
 private:

--- a/ProjectJormag/LevelManager.h
+++ b/ProjectJormag/LevelManager.h
@@ -11,17 +11,17 @@
 
 class LevelManager : public Jormag::StateManager {
 private:	
-	Graphics* mGraphics;
+	Graphics* mGraphics = nullptr;
 
 	// Game Objects
-	Camera* mCamera;
-	Level* mCurrLevel;
-	Player* mPlayer;
+	Camera* mCamera = nullptr;
+	Level* mCurrLevel = nullptr;
+	Player* mPlayer = nullptr;
 
 	// Flavour
 	unsigned int mLastCamPan;
-	Texture* mStartLabel;
-	Texture* mScoreLabel;
+	Texture* mStartLabel = nullptr;
+	Texture* mScoreLabel = nullptr;
 	bool mLevelFinishing;
 	int mScreenOpacity;
 


### PR DESCRIPTION
Hi,

This PR will null initialize some of the pointer variables. The game failed to launch until these were set, I didn't search for others. Maybe your compiler has some setting to allow this to happen automatically, I am using gcc 8.2 with msys2/mingw64.