### PR TITLE
Add size modifier to enum forward declaration

### DIFF
--- a/ProjectJormag/GameEntity.h
+++ b/ProjectJormag/GameEntity.h
@@ -9,7 +9,7 @@
 
 class Level;
 
-enum DeathType {
+enum DeathType : char {
 	NONE,
 	ATTACK,
 	CRUSH,

--- a/ProjectJormag/GameLossScreen.h
+++ b/ProjectJormag/GameLossScreen.h
@@ -5,7 +5,7 @@
 
 #include "Jormag.h"
 
-enum DeathType;
+enum DeathType: char;
 
 class GameLossScreen : public GameObject {
 private:


### PR DESCRIPTION
Hi,

This PR will fix a compile time error. My compiler (gcc 8.2) didn't allow forward declaration of enum types without size is set. It might be unnecessary for planned compiler suites.